### PR TITLE
Add request pseudo-header slots to client-stream

### DIFF
--- a/core/classes.lisp
+++ b/core/classes.lisp
@@ -119,28 +119,13 @@ pretending that connection of connection is the same connection can be useful."
    (depends-on       :accessor get-depends-on       :initarg :depends-on)
    (seen-text-header :accessor get-seen-text-header :initarg :seen-text-header
                      :documentation
-                     "Set if in the header block a non-pseudo header was already seen."))
-  (:default-initargs :window-size 0
-   ;;   All streams are initially assigned a non-exclusive dependency on
-   ;;   stream 0x0.  Pushed streams (Section 8.2) initially depend on their
-   ;;   associated stream.  In both cases, streams are assigned a default
-   ;;   weight of 16.
-                     :weight 16
-                     :depends-on '(:non-exclusive 0)
-                     :seen-text-header nil)
-  (:documentation
-   "Representation of HTTP/2 stream. See RFC7540."))
-
-(defmethod initialize-instance :after ((stream http2-stream) &key connection)
-  "Set the window parameters of new stream from the connection defaults."
-  (with-slots (peer-window-size window-size) stream
-    (unless  (slot-boundp stream 'peer-window-size)
-      (setf peer-window-size (get-initial-peer-window-size connection)))
-    (unless  (slot-boundp stream 'window-size)
-      (setf window-size (get-initial-window-size connection)))))
-
-(defclass server-stream (http2-stream)
-  ((method    :accessor get-method    :initarg :method
+                     "Set if in the header block a non-pseudo header was already seen.")
+   ;; Request pseudo-header slots.  Server streams populate these from
+   ;; incoming client request headers; client streams may carry them for
+   ;; diagnostics (log-closed-stream, print-object).  Shared here so that
+   ;; code handling either side uniformly can access them via the same
+   ;; accessor generic functions.
+   (method    :accessor get-method    :initarg :method
               :documentation
               "The HTTP method ([RFC7231], Section 4)")
    (scheme    :accessor get-scheme    :initarg :scheme
@@ -154,10 +139,32 @@ pretending that connection of connection is the same connection can be useful."
               :documentation
               "The authority portion of the target URI ([RFC3986], Section 3.2)")
    (path      :accessor get-path      :initarg :path
-              :type string
+              :type (or null string)
               :documentation "The path and query parts of the target URI"))
-  (:default-initargs :method nil :scheme nil :authority nil :path nil)
-  (:documentation "Server streams need to track attributes from the client headers such as PATH."))
+  (:default-initargs :window-size 0
+   ;;   All streams are initially assigned a non-exclusive dependency on
+   ;;   stream 0x0.  Pushed streams (Section 8.2) initially depend on their
+   ;;   associated stream.  In both cases, streams are assigned a default
+   ;;   weight of 16.
+                     :weight 16
+                     :depends-on '(:non-exclusive 0)
+                     :seen-text-header nil
+                     :method nil :scheme nil :authority nil :path nil)
+  (:documentation
+   "Representation of HTTP/2 stream. See RFC7540."))
+
+(defmethod initialize-instance :after ((stream http2-stream) &key connection)
+  "Set the window parameters of new stream from the connection defaults."
+  (with-slots (peer-window-size window-size) stream
+    (unless  (slot-boundp stream 'peer-window-size)
+      (setf peer-window-size (get-initial-peer-window-size connection)))
+    (unless  (slot-boundp stream 'window-size)
+      (setf window-size (get-initial-window-size connection)))))
+
+(defclass server-stream (http2-stream)
+  ()
+  (:documentation "Server streams track the request pseudo-headers (method,
+scheme, authority, path) inherited from http2-stream."))
 
 (defmethod print-object ((stream server-stream) out)
   (if *print-escape*


### PR DESCRIPTION
## Summary

- Moves `method`, `scheme`, `authority`, `path` slots from `server-stream` up to the `http2-stream` common superclass
- Both `server-stream` and `client-stream` instances now inherit the slots and their accessor generic functions
- Fixes `no-applicable-method-error` on `get-path`, `get-method`, etc. when called on client streams during `http-stream-error` handling

## Motivation

In v2.0.5, `log-closed-stream` (core/frames/headers.lisp line 103) calls `(get-path stream)` on any h2-stream during `http-stream-error` handling. `parse-header-frame*` catches http-stream-errors and invokes `log-closed-stream`, so this code path fires for both client and server streams.

Previously only `server-stream` had these slots, so calling `get-path` on a `client-stream` signalled `no-applicable-method-error`, killing the client reactor silently.

## Change from v1 of this PR

The original PR added the slots to `client-stream`, duplicating them across the two parallel stream classes. Following Tomas's suggestion, this revision moves them up to the common `http2-stream` superclass instead. Benefits:

- Single set of slots shared by both branches via inheritance
- No duplication
- Accessor generic functions now work uniformly on any h2-stream
- `server-stream` API is unchanged (all slots still accessible via the same accessor GFs, just inherited rather than direct)
- `client-stream` API is unchanged (it simply gains access to the slots via inheritance)

## Backward compatibility

- Existing code that creates `server-stream` instances works unchanged -- all slots are still present, just via inheritance
- Existing code that uses `get-method`, `get-scheme`, `get-authority`, `get-path` on server streams works unchanged
- New benefit: the same accessors now work on client streams too, and on any future h2-stream subclass
- Slot default-initargs (`:method nil :scheme nil :authority nil :path nil`) moved to `http2-stream`
- `(type string)` on the path slot relaxed to `(type (or null string))` since client streams initialize it to NIL

## Test plan

- [x] Verified on CL-HTTP SBCL port: server H2 (curl), client H2 (nghttp2.org external server), connection pooling
- [x] Verified on CL-HTTP LispWorks port: same tests
- [x] Cold compile clean on both ports
- [x] H2 client reactor no longer dies on http-stream-error during header processing
- [x] `(type-of stream)` and class precedence list still correct for server-stream instances

## Files changed

- `core/classes.lisp` -- single file, 27 insertions, 20 deletions. Net: +7 lines.
