### PR TITLE
Export slot names from http2/core used cross-package

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -21,7 +21,13 @@
   (:import-from #:mgl-pax #:defsection #:glossary-term #:section
                 #:define-glossary-term)
   (:import-from :alexandria
-                #:read-stream-content-into-string #:read-stream-content-into-byte-vector))
+                #:read-stream-content-into-string #:read-stream-content-into-byte-vector)
+  ;; Slot names referenced by with-slots in http2/stream-overlay
+  ;; (payload-streams.lisp).  Without this export, :use only inherits
+  ;; exported symbols per ANSI CL, and with-slots would intern fresh
+  ;; symbols that don't match the actual slot names.
+  (:export #:connection #:peer-window-size #:window-size #:state
+           #:output-buffer #:network-stream))
 
 (mgl-pax:define-package #:http2/cl+ssl
   (:use #:cl #:http2/core #:cl+ssl #:mgl-pax #:http2/openssl))


### PR DESCRIPTION
## Summary

- Export 6 slot names from `http2/core` that are referenced via `with-slots` in `http2/stream-overlay` (`payload-streams.lisp`): `connection`, `peer-window-size`, `window-size`, `state`, `output-buffer`, `network-stream`.

## Problem

`payload-streams.lisp` is `(in-package http2/stream-overlay)` and uses `with-slots` to access slots defined on classes in `http2/core` (e.g., `flow-control-mixin`, `http2-stream-minimal`, `buffered-stream`, `http2-connection`).

Since `http2/stream-overlay` `:use`s `http2/core`, only **exported** symbols are inherited. These slot names are currently internal to `http2/core`. Per ANSI CL, `with-slots` in the `http2/stream-overlay` package context should intern fresh symbols that don't match the actual slot definitions, causing `slot-missing` errors at runtime.

This currently works because `mgl-pax:define-package` happens to make the symbols accessible across packages. But the correctness depends on `mgl-pax` behavior rather than the ANSI CL package system. Downstream code that subclasses `http2-stream` from other packages encounters this issue and requires `slot-missing` workarounds.

## Fix

Add `:export` for the 6 slot names to the `http2/core` package definition. This makes the cross-package `with-slots` references correct per ANSI CL regardless of which `defpackage` implementation is used.

## Test plan

- [ ] Verify existing tests pass with the export
- [ ] Verify `(eq (find-symbol "PEER-WINDOW-SIZE" :http2/stream-overlay) (find-symbol "PEER-WINDOW-SIZE" :http2/core))` returns T
